### PR TITLE
동시성 이슈 해결 및 테스트

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# 콘서트 예매 대기열 서비스
+
+## Wiki
+
+- [프로젝트 마일스톤](doc/1_Milestone.md)
+- [UML](doc/2_UML.md)
+- [ERD](doc/3_ERD.md)
+- [API 명세](doc/4_API_docs.md)

--- a/src/main/java/com/sion/concertbooking/application/PaymentFacade.java
+++ b/src/main/java/com/sion/concertbooking/application/PaymentFacade.java
@@ -50,8 +50,7 @@ public class PaymentFacade {
 
         // 예약한 가격만큼 포인트를 차감한다.
         long userId = criteria.userId();
-        long usedPointId = pointService.usePoint(userId, totalPrice);
-        PointInfo currentPoint = pointService.getPointById(usedPointId);
+        PointInfo currentPoint = pointService.usePoint(userId, totalPrice);
 
         // 예약 상태를 결제 완료로 변경한다.
         reservationIds.forEach(reservationService::completeReservation);

--- a/src/main/java/com/sion/concertbooking/application/PointCharger.java
+++ b/src/main/java/com/sion/concertbooking/application/PointCharger.java
@@ -33,14 +33,12 @@ public class PointCharger {
         paymentCharger.payment(amount);
 
         // 2. 포인트 충전 처리
-        long chargedPointId = pointService.chargePoint(userId, amount);
+        PointInfo chargedPointInfo = pointService.chargePoint(userId, amount);
 
         // 3. 포인트 충전 이력 저장
-        long chargedPointHistoryId = pointHistoryService.chargePointHistory(chargedPointId, amount);
+        PointHistoryInfo chargedPointHistory = pointHistoryService.chargePointHistory(chargedPointInfo.id(), amount);
 
-        PointInfo savedPoint = pointService.getPointById(chargedPointId);
-        PointHistoryInfo savedPointHistory = pointHistoryService.getPointHistoryById(chargedPointHistoryId);
-        return PointResult.Charge.of(savedPoint, savedPointHistory, paymentType);
+        return PointResult.Charge.of(chargedPointInfo, chargedPointHistory, paymentType);
     }
 
 }

--- a/src/main/java/com/sion/concertbooking/application/PointDeductor.java
+++ b/src/main/java/com/sion/concertbooking/application/PointDeductor.java
@@ -22,13 +22,10 @@ public class PointDeductor {
     @Transactional
     public PointResult.Use usePoint(long userId, int amount) {
         // 1. 포인트 사용
-        long usedPointId = pointService.usePoint(userId, amount);
+        PointInfo pointInfo = pointService.usePoint(userId, amount);
         // 2. 포인트 사용 이력 저장
-        long usedPointHistoryId = pointHistoryService.usePointHistory(usedPointId, amount);
+        PointHistoryInfo pointHistoryInfo = pointHistoryService.usePointHistory(pointInfo.id(), amount);
 
-        PointInfo savedPoint = pointService.getPointById(usedPointId);
-        PointHistoryInfo savedPointHistory = pointHistoryService.getPointHistoryById(usedPointHistoryId);
-
-        return PointResult.Use.of(savedPoint, savedPointHistory);
+        return PointResult.Use.of(pointInfo, pointHistoryInfo);
     }
 }

--- a/src/main/java/com/sion/concertbooking/application/result/PointResult.java
+++ b/src/main/java/com/sion/concertbooking/application/result/PointResult.java
@@ -32,7 +32,7 @@ public class PointResult {
                     pointHistoryInfo.amount(),
                     pointInfo.amount(),
                     paymentType,
-                    pointInfo.updatedAt()
+                    pointHistoryInfo.updatedAt()
             );
         }
     }
@@ -53,7 +53,7 @@ public class PointResult {
                     pointInfo.userId(),
                     pointHistoryInfo.amount(),
                     pointInfo.amount(),
-                    pointInfo.updatedAt()
+                    pointHistoryInfo.updatedAt()
             );
         }
     }

--- a/src/main/java/com/sion/concertbooking/domain/entity/Point.java
+++ b/src/main/java/com/sion/concertbooking/domain/entity/Point.java
@@ -25,6 +25,15 @@ public class Point extends BaseEntity {
     @Column(name = "amount", nullable = false)
     private int amount;
 
+    private Point(long userId) {
+        this.userId = userId;
+        this.amount = 0;
+    }
+
+    public static Point createWallet(long userId) {
+        return new Point(userId);
+    }
+
     public void chargePoint(int point) {
         if (point <= 0) {
             throw new IllegalArgumentException("0 이하의 금액을 충전할 수 없습니다.");

--- a/src/main/java/com/sion/concertbooking/domain/entity/Reservation.java
+++ b/src/main/java/com/sion/concertbooking/domain/entity/Reservation.java
@@ -62,7 +62,7 @@ public class Reservation extends BaseEntity {
     @Column(name = "expired_at", nullable = false)
     private LocalDateTime expiredAt;
 
-    public static Reservation of(
+    public static Reservation createReservation(
             long userId,
             long concertId,
             String concertTitle,

--- a/src/main/java/com/sion/concertbooking/domain/repository/PointRepository.java
+++ b/src/main/java/com/sion/concertbooking/domain/repository/PointRepository.java
@@ -1,8 +1,16 @@
 package com.sion.concertbooking.domain.repository;
 
 import com.sion.concertbooking.domain.entity.Point;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PointRepository extends JpaRepository<Point, Long> {
     Point findByUserId(long userId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT p FROM Point p WHERE p.userId = :userId")
+    Point findByUserIdWithLock(@Param("userId") long userId);
 }

--- a/src/main/java/com/sion/concertbooking/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/sion/concertbooking/domain/repository/ReservationRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface ReservationRepository {
     List<Reservation> saveAll(List<Reservation> reservations);
 
-    List<Reservation> findByConcertScheduleIdAndSeatId(long concertScheduleId, long seatId);
+    List<Reservation> findByConcertScheduleIdAndSeatIdWithLock(long concertScheduleId, long seatId);
 
     Optional<Reservation> findById(long reservationId);
 }

--- a/src/main/java/com/sion/concertbooking/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/sion/concertbooking/domain/repository/ReservationRepository.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ReservationRepository {
+    Reservation save(Reservation reservation);
+
     List<Reservation> saveAll(List<Reservation> reservations);
 
     List<Reservation> findByConcertScheduleIdAndSeatIdsWithLock(long concertScheduleId, List<Long> seatIds);

--- a/src/main/java/com/sion/concertbooking/domain/repository/ReservationRepository.java
+++ b/src/main/java/com/sion/concertbooking/domain/repository/ReservationRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 public interface ReservationRepository {
     List<Reservation> saveAll(List<Reservation> reservations);
 
-    List<Reservation> findByConcertScheduleIdAndSeatIdWithLock(long concertScheduleId, long seatId);
+    List<Reservation> findByConcertScheduleIdAndSeatIdsWithLock(long concertScheduleId, List<Long> seatIds);
 
     Optional<Reservation> findById(long reservationId);
 }

--- a/src/main/java/com/sion/concertbooking/domain/service/PointHistoryService.java
+++ b/src/main/java/com/sion/concertbooking/domain/service/PointHistoryService.java
@@ -19,17 +19,17 @@ public class PointHistoryService {
     }
 
     @Transactional
-    public long chargePointHistory(long pointId, int amount) {
+    public PointHistoryInfo chargePointHistory(long pointId, int amount) {
         PointHistory pointHistoryToCharge = PointHistory.ofCharge(pointId, amount);
         PointHistory chargedPointHistory = pointHistoryRepository.save(pointHistoryToCharge);
-        return chargedPointHistory.getId();
+        return PointHistoryInfo.fromEntity(chargedPointHistory);
     }
 
     @Transactional
-    public long usePointHistory(long pointId, int amount) {
+    public PointHistoryInfo usePointHistory(long pointId, int amount) {
         PointHistory pointHistoryToUse = PointHistory.ofUse(pointId, amount);
         PointHistory usedPointHistory = pointHistoryRepository.save(pointHistoryToUse);
-        return usedPointHistory.getId();
+        return PointHistoryInfo.fromEntity(usedPointHistory);
     }
 
     public PointHistoryInfo getPointHistoryById(long pointHistoryId) {

--- a/src/main/java/com/sion/concertbooking/domain/service/PointService.java
+++ b/src/main/java/com/sion/concertbooking/domain/service/PointService.java
@@ -16,23 +16,23 @@ public class PointService {
     }
 
     @Transactional
-    public long chargePoint(long userId, int amount) {
+    public PointInfo chargePoint(long userId, int amount) {
         Point point = pointRepository.findByUserIdWithLock(userId);
         if (point == null) {
             throw new IllegalArgumentException("존재하지 않는 포인트입니다.");
         }
         point.chargePoint(amount);
-        return point.getId();
+        return PointInfo.fromEntity(point);
     }
 
     @Transactional
-    public long usePoint(long userId, int amount) {
+    public PointInfo usePoint(long userId, int amount) {
         Point point = pointRepository.findByUserIdWithLock(userId);
         if (point == null) {
             throw new IllegalArgumentException("존재하지 않는 포인트입니다.");
         }
         point.usePoint(amount);
-        return point.getId();
+        return PointInfo.fromEntity(point);
     }
 
     public PointInfo getPointById(long pointId) {

--- a/src/main/java/com/sion/concertbooking/domain/service/PointService.java
+++ b/src/main/java/com/sion/concertbooking/domain/service/PointService.java
@@ -17,7 +17,7 @@ public class PointService {
 
     @Transactional
     public long chargePoint(long userId, int amount) {
-        Point point = pointRepository.findByUserId(userId);
+        Point point = pointRepository.findByUserIdWithLock(userId);
         if (point == null) {
             throw new IllegalArgumentException("존재하지 않는 포인트입니다.");
         }
@@ -27,7 +27,7 @@ public class PointService {
 
     @Transactional
     public long usePoint(long userId, int amount) {
-        Point point = pointRepository.findByUserId(userId);
+        Point point = pointRepository.findByUserIdWithLock(userId);
         if (point == null) {
             throw new IllegalArgumentException("존재하지 않는 포인트입니다.");
         }
@@ -47,6 +47,13 @@ public class PointService {
             throw new IllegalArgumentException("존재하지 않는 포인트입니다.");
         }
         return PointInfo.fromEntity(point);
+    }
+
+    @Transactional
+    public PointInfo createPoint(long userId) {
+        Point pointWallet = Point.createWallet(userId);
+        Point savedPoint = pointRepository.save(pointWallet);
+        return PointInfo.fromEntity(savedPoint);
     }
 
 }

--- a/src/main/java/com/sion/concertbooking/domain/service/ReservationService.java
+++ b/src/main/java/com/sion/concertbooking/domain/service/ReservationService.java
@@ -21,8 +21,9 @@ public class ReservationService {
         this.reservationRepository = reservationRepository;
     }
 
+    @Transactional
     public boolean isReservedSeat(long concertScheduleId, long seatId, LocalDateTime now) {
-        return reservationRepository.findByConcertScheduleIdAndSeatId(concertScheduleId, seatId)
+        return reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId)
                 .stream()
                 // 예약완료 혹은 결제대기 중인 예약이 하나라도 있는지 확인
                 .anyMatch(reservation -> reservation.isReserved() || (reservation.isSuspend(now)));
@@ -48,16 +49,31 @@ public class ReservationService {
     }
 
     @Transactional
-    public List<ReservationInfo> createReservations(ReservationCreateCommand createDto) {
-        List<ReservationCreateCommand.SeatCreateCommand> seats = createDto.getSeats();
+    public List<ReservationInfo> createReservations(ReservationCreateCommand command) {
+        LocalDateTime now = command.getNow();
+        long concertScheduleId = command.getConcertScheduleId();
+        List<ReservationCreateCommand.SeatCreateCommand> seats = command.getSeats();
+
+        // 1. 예약된 좌석이 없는지 확인한다.
+        for (ReservationCreateCommand.SeatCreateCommand seat : seats) {
+            boolean isReserved = reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seat.getSeatId())
+                    .stream()
+                    // 예약완료 혹은 결제대기 중인 예약이 하나라도 있는지 확인
+                    .anyMatch(reservation -> reservation.isReserved() || (reservation.isSuspend(now)));
+            if (isReserved) {
+                throw new IllegalArgumentException("이미 예약중인 좌석입니다.");
+            }
+        }
+
+        // 2. 모든 좌석에 대해 예약을 생성한다.
         List<Reservation> reservations = seats.stream()
-                .map(seat -> Reservation.of(
-                        createDto.getUserId(),
-                        createDto.getConcertId(),
-                        createDto.getConcertTitle(),
-                        createDto.getConcertScheduleId(),
-                        createDto.getPlayDateTime(),
-                        createDto.getNow(),
+                .map(seat -> Reservation.createReservation(
+                        command.getUserId(),
+                        command.getConcertId(),
+                        command.getConcertTitle(),
+                        command.getConcertScheduleId(),
+                        command.getPlayDateTime(),
+                        command.getNow(),
                         seat.getSeatId(),
                         seat.getSeatNum(),
                         seat.getSeatGrade(),

--- a/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationCoreRepository.java
+++ b/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationCoreRepository.java
@@ -25,8 +25,8 @@ public class ReservationCoreRepository implements ReservationRepository {
     }
 
     @Override
-    public List<Reservation> findByConcertScheduleIdAndSeatId(final long concertScheduleId, final long seatId) {
-        return reservationJpaRepository.findByConcertScheduleIdAndSeatId(concertScheduleId, seatId);
+    public List<Reservation> findByConcertScheduleIdAndSeatIdWithLock(final long concertScheduleId, final long seatId) {
+        return reservationJpaRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId);
     }
 
     @Override

--- a/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationCoreRepository.java
+++ b/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationCoreRepository.java
@@ -20,6 +20,11 @@ public class ReservationCoreRepository implements ReservationRepository {
 
 
     @Override
+    public Reservation save(final Reservation reservation) {
+        return reservationJpaRepository.save(reservation);
+    }
+
+    @Override
     public List<Reservation> saveAll(List<Reservation> reservations) {
         return reservationJpaRepository.saveAll(reservations);
     }

--- a/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationCoreRepository.java
+++ b/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationCoreRepository.java
@@ -25,8 +25,8 @@ public class ReservationCoreRepository implements ReservationRepository {
     }
 
     @Override
-    public List<Reservation> findByConcertScheduleIdAndSeatIdWithLock(final long concertScheduleId, final long seatId) {
-        return reservationJpaRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId);
+    public List<Reservation> findByConcertScheduleIdAndSeatIdsWithLock(final long concertScheduleId, final List<Long> seatIds) {
+        return reservationJpaRepository.findByConcertScheduleIdAndSeatIdsWithLock(concertScheduleId, seatIds);
     }
 
     @Override

--- a/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationJpaRepository.java
+++ b/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationJpaRepository.java
@@ -1,12 +1,22 @@
 package com.sion.concertbooking.infrastructure.repository;
 
 import com.sion.concertbooking.domain.entity.Reservation;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface ReservationJpaRepository extends JpaRepository<Reservation, Long> {
-    List<Reservation> findByConcertScheduleIdAndSeatId(long concertScheduleId, long seatId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Reservation r WHERE r.concertScheduleId = :concertScheduleId AND r.seatId = :seatId")
+    List<Reservation> findByConcertScheduleIdAndSeatIdWithLock(
+            @Param("concertScheduleId") long concertScheduleId,
+            @Param("seatId") long seatId
+    );
 }

--- a/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationJpaRepository.java
+++ b/src/main/java/com/sion/concertbooking/infrastructure/repository/ReservationJpaRepository.java
@@ -14,9 +14,9 @@ import java.util.List;
 public interface ReservationJpaRepository extends JpaRepository<Reservation, Long> {
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT r FROM Reservation r WHERE r.concertScheduleId = :concertScheduleId AND r.seatId = :seatId")
-    List<Reservation> findByConcertScheduleIdAndSeatIdWithLock(
+    @Query("SELECT r FROM Reservation r WHERE r.concertScheduleId = :concertScheduleId AND r.seatId IN :seatIds")
+    List<Reservation> findByConcertScheduleIdAndSeatIdsWithLock(
             @Param("concertScheduleId") long concertScheduleId,
-            @Param("seatId") long seatId
+            @Param("seatIds") List<Long> seatIds
     );
 }

--- a/src/test/java/com/sion/concertbooking/application/PointChargerTest.java
+++ b/src/test/java/com/sion/concertbooking/application/PointChargerTest.java
@@ -1,0 +1,84 @@
+package com.sion.concertbooking.application;
+
+import com.sion.concertbooking.domain.info.PointInfo;
+import com.sion.concertbooking.domain.service.PointHistoryService;
+import com.sion.concertbooking.domain.service.PointService;
+import com.sion.concertbooking.test.TestDataCleaner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PointChargerTest {
+
+    @Autowired
+    PointCharger pointCharger;
+
+    @Autowired
+    PointService pointService;
+
+    @Autowired
+    PointHistoryService pointHistoryService;
+
+    @Autowired
+    TestDataCleaner testDataCleaner;
+
+    @BeforeEach
+    void setUp() {
+        testDataCleaner.cleanUp();
+    }
+
+    @DisplayName("100원씩 20번 충전하면 총 2000원이 충전되고, 20번의 충전 내역이 기록되어야 한다.")
+    @Test
+    void chargePointCuncurrently() throws Exception {
+        // given
+        long userId = 1L;
+        int amount = 100;
+        pointService.createPoint(userId); // 포인트 지갑 생성
+
+        final int numOfExecute = 20;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(numOfExecute);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < numOfExecute; i++) {
+            executorService.submit(() -> {
+                try {
+                    pointCharger.chargePoint(userId, amount, PaymentType.FREE);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(numOfExecute);
+        assertThat(failCount.get()).isZero();
+        
+        PointInfo pointInfo = pointService.getPointByUserId(userId);
+        assertThat(pointInfo.amount())
+                .as("총 충전된 금액은 2000원이어야 한다.")
+                .isEqualTo(2000);
+
+        assertThat(pointHistoryService.getChargedPointHistories(pointInfo.id(), PageRequest.of(0, 50)))
+                .as("20번의 충전 내역이 기록되어야 한다.")
+                .hasSize(numOfExecute);
+    }
+}

--- a/src/test/java/com/sion/concertbooking/domain/entity/ReservationTest.java
+++ b/src/test/java/com/sion/concertbooking/domain/entity/ReservationTest.java
@@ -21,7 +21,7 @@ class ReservationTest {
         LocalDateTime playDateTime = LocalDateTime.of(2025, 2, 1, 19, 0, 0);
 
         // when
-        Reservation reservation = Reservation.of(
+        Reservation reservation = Reservation.createReservation(
                 1L, 1L, "콘서트 타이틀",
                 1L, playDateTime, now,
                 1L, 1, SeatGrade.VIP, 100_000
@@ -39,7 +39,7 @@ class ReservationTest {
         LocalDateTime playDateTime = LocalDateTime.of(2025, 1, 10, 19, 0, 0);
 
         // when
-        Reservation reservation = Reservation.of(
+        Reservation reservation = Reservation.createReservation(
                 1L, 1L, "콘서트 타이틀",
                 1L, playDateTime, now,
                 1L, 1, SeatGrade.VIP, 100_000

--- a/src/test/java/com/sion/concertbooking/domain/service/PointServiceConcurrencyTest.java
+++ b/src/test/java/com/sion/concertbooking/domain/service/PointServiceConcurrencyTest.java
@@ -1,7 +1,6 @@
-package com.sion.concertbooking.integrationtest.concurrency;
+package com.sion.concertbooking.domain.service;
 
 import com.sion.concertbooking.domain.info.PointInfo;
-import com.sion.concertbooking.domain.service.PointService;
 import com.sion.concertbooking.test.TestDataCleaner;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceConcurrencyTest.java
+++ b/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceConcurrencyTest.java
@@ -16,6 +16,8 @@ import org.instancio.Instancio;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -31,6 +33,8 @@ import static org.instancio.Select.field;
 
 @SpringBootTest
 class ReservationServiceConcurrencyTest {
+
+    Logger logger = LoggerFactory.getLogger(ReservationServiceConcurrencyTest.class);
 
     @Autowired
     ReservationService reservationService;
@@ -95,6 +99,7 @@ class ReservationServiceConcurrencyTest {
                 reservationService.createReservations(createCommandUser1);
                 successCount.incrementAndGet();
             } catch (Exception e) {
+                logger.error("error", e);
                 failCount.incrementAndGet();
             } finally {
                 latch.countDown();
@@ -105,6 +110,7 @@ class ReservationServiceConcurrencyTest {
                 reservationService.createReservations(createCommandUser2);
                 successCount.incrementAndGet();
             } catch (Exception e) {
+                logger.error("error", e);
                 failCount.incrementAndGet();
             } finally {
                 latch.countDown();
@@ -115,6 +121,7 @@ class ReservationServiceConcurrencyTest {
                 reservationService.createReservations(createCommandUser3);
                 successCount.incrementAndGet();
             } catch (Exception e) {
+                logger.error("error", e);
                 failCount.incrementAndGet();
             } finally {
                 latch.countDown();

--- a/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceConcurrencyTest.java
+++ b/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceConcurrencyTest.java
@@ -5,6 +5,7 @@ import com.sion.concertbooking.domain.entity.Concert;
 import com.sion.concertbooking.domain.entity.ConcertSchedule;
 import com.sion.concertbooking.domain.entity.Reservation;
 import com.sion.concertbooking.domain.entity.Seat;
+import com.sion.concertbooking.domain.enums.ReservationStatus;
 import com.sion.concertbooking.domain.enums.SeatGrade;
 import com.sion.concertbooking.domain.repository.ConcertRepository;
 import com.sion.concertbooking.domain.repository.ConcertScheduleRepository;
@@ -128,10 +129,13 @@ class ReservationServiceConcurrencyTest {
 
         List<Reservation> allReservations = reservationJpaRepository.findAll();
         assertThat(allReservations)
-                .as("오직 유저 한명이 시도한 좌석 2개에 대한 예약만 생성되어야 한다.")
+                .as("오직 유저 한명이 시도한 좌석 2개에 대한 예약만 생성되어야 하고 초기상태는 SUSPEND여야 한다.")
                 .hasSize(2);
         assertThat(allReservations.get(0).getUserId())
                 .isEqualTo(allReservations.get(1).getUserId());
+        allReservations.forEach(reservation -> {
+            assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.SUSPEND);
+        });
     }
 
     private Concert createConcert() {

--- a/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceConcurrencyTest.java
+++ b/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceConcurrencyTest.java
@@ -1,0 +1,161 @@
+package com.sion.concertbooking.domain.service;
+
+import com.sion.concertbooking.domain.command.ReservationCreateCommand;
+import com.sion.concertbooking.domain.entity.Concert;
+import com.sion.concertbooking.domain.entity.ConcertSchedule;
+import com.sion.concertbooking.domain.entity.Reservation;
+import com.sion.concertbooking.domain.entity.Seat;
+import com.sion.concertbooking.domain.enums.SeatGrade;
+import com.sion.concertbooking.domain.repository.ConcertRepository;
+import com.sion.concertbooking.domain.repository.ConcertScheduleRepository;
+import com.sion.concertbooking.domain.repository.SeatRepository;
+import com.sion.concertbooking.infrastructure.repository.ReservationJpaRepository;
+import com.sion.concertbooking.test.TestDataCleaner;
+import org.instancio.Instancio;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.instancio.Select.field;
+
+@SpringBootTest
+class ReservationServiceConcurrencyTest {
+
+    @Autowired
+    ReservationService reservationService;
+
+    @Autowired
+    SeatRepository seatRepository;
+
+    @Autowired
+    ConcertRepository concertRepository;
+
+    @Autowired
+    ConcertScheduleRepository concertScheduleRepository;
+
+    @Autowired
+    ReservationJpaRepository reservationJpaRepository;
+
+    @Autowired
+    TestDataCleaner testDataCleaner;
+
+    @BeforeEach
+    void setUp() {
+        testDataCleaner.cleanUp();
+    }
+
+    @DisplayName("동시에 같은 좌석을 3명이 시도하면, 1명만 성공하고 2명은 실패해야 한다.")
+    @Test
+    void createReservationsConcurrently() throws Exception {
+        // given
+        Concert concert = concertRepository.save(createConcert());
+        ConcertSchedule concertSchedule = concertScheduleRepository.save(createConcertSchedule(concert.getId()));
+        Seat seat1 = seatRepository.save(createSeat(1, SeatGrade.VIP, 170_000));
+        Seat seat2 = seatRepository.save(createSeat(2, SeatGrade.VIP, 170_000));
+
+        long concertId = concert.getId();
+        long concertScheduleId = concertSchedule.getId();
+        LocalDateTime now = LocalDateTime.of(2025, 1, 9, 1, 0);
+        LocalDateTime playDateTime = LocalDateTime.of(2025, 1, 20, 17, 0);
+
+        List<ReservationCreateCommand.SeatCreateCommand> seatCreateCommands = List.of(
+                new ReservationCreateCommand.SeatCreateCommand(seat1.getId(), seat1.getSeatNum(), seat1.getSeatGrade(), seat1.getSeatPrice()),
+                new ReservationCreateCommand.SeatCreateCommand(seat2.getId(), seat1.getSeatNum(), seat2.getSeatGrade(), seat2.getSeatPrice())
+        );
+        ReservationCreateCommand createCommandUser1 = new ReservationCreateCommand(
+                1L, concertId, "지킬앤하이드", concertScheduleId, playDateTime, now,
+                seatCreateCommands);
+        ReservationCreateCommand createCommandUser2 = new ReservationCreateCommand(
+                2L, concertId, "지킬앤하이드", concertScheduleId, playDateTime, now,
+                seatCreateCommands);
+        ReservationCreateCommand createCommandUser3 = new ReservationCreateCommand(
+                3L, concertId, "지킬앤하이드", concertScheduleId, playDateTime, now,
+                seatCreateCommands);
+
+        final int numOfExecute = 3;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(numOfExecute);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        executorService.submit(() -> {
+            try {
+                reservationService.createReservations(createCommandUser1);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                latch.countDown();
+            }
+        });
+        executorService.submit(() -> {
+            try {
+                reservationService.createReservations(createCommandUser2);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                latch.countDown();
+            }
+        });
+        executorService.submit(() -> {
+            try {
+                reservationService.createReservations(createCommandUser3);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                latch.countDown();
+            }
+        });
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(2);
+
+        List<Reservation> allReservations = reservationJpaRepository.findAll();
+        assertThat(allReservations)
+                .as("오직 유저 한명이 시도한 좌석 2개에 대한 예약만 생성되어야 한다.")
+                .hasSize(2);
+        assertThat(allReservations.get(0).getUserId())
+                .isEqualTo(allReservations.get(1).getUserId());
+    }
+
+    private Concert createConcert() {
+        return Instancio.of(Concert.class)
+                .set(field(Concert::getId), null)
+                .create();
+    }
+
+    private ConcertSchedule createConcertSchedule(long concertId) {
+        return Instancio.of(ConcertSchedule.class)
+                .set(field(ConcertSchedule::getId), null)
+                .set(field(ConcertSchedule::getConcertId), concertId)
+                .create();
+    }
+
+    private Seat createSeat(int seatNum, SeatGrade seatGrade, int seatPrice) {
+        return Instancio.of(Seat.class)
+                .set(field(Seat::getId), null)
+                .set(field(Seat::getTheatreId), 1L)
+                .set(field(Seat::getSeatNum), seatNum)
+                .set(field(Seat::getSeatGrade), seatGrade)
+                .set(field(Seat::getSeatPrice), seatPrice)
+                .create();
+    }
+
+
+}

--- a/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceTest.java
+++ b/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceTest.java
@@ -36,14 +36,14 @@ class ReservationServiceTest {
     void isReservedSeatFalseWhenReservationIsEmpty() {
         // given
         long concertScheduleId = 1L;
-        long seatId = 1L;
+        List<Long> seatIds = List.of(1L, 2L, 3L);
         LocalDateTime now = LocalDateTime.of(2025, 1, 6, 23, 0, 0);
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdsWithLock(concertScheduleId, seatIds))
                 .thenReturn(List.of());
 
         // when
-        boolean result = sut.isReservedSeat(concertScheduleId, seatId, now);
+        boolean result = sut.isReservedSeats(concertScheduleId, seatIds, now);
 
         // then
         assertThat(result).isFalse();
@@ -54,17 +54,17 @@ class ReservationServiceTest {
     void isReservedSeatFalseWhenAllReservationIsCanceled() {
         // given
         long concertScheduleId = 1L;
-        long seatId = 1L;
+        List<Long> seatIds = List.of(1L, 2L, 3L);
         LocalDateTime now = LocalDateTime.of(2025, 1, 6, 23, 0, 0);
         List<Reservation> reservations = Instancio.ofList(Reservation.class).size(3)
                 .set(field(Reservation::getStatus), ReservationStatus.CANCEL)
                 .create();
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdsWithLock(concertScheduleId, seatIds))
                 .thenReturn(reservations);
 
         // when
-        boolean result = sut.isReservedSeat(concertScheduleId, seatId, now);
+        boolean result = sut.isReservedSeats(concertScheduleId, seatIds, now);
 
         // then
         assertThat(result).isFalse();
@@ -75,17 +75,17 @@ class ReservationServiceTest {
     void isReservedSeatTrueWhenAllReservationIsReserved() {
         // given
         long concertScheduleId = 1L;
-        long seatId = 1L;
+        List<Long> seatIds = List.of(1L, 2L, 3L);
         LocalDateTime now = LocalDateTime.of(2025, 1, 6, 23, 0, 0);
         List<Reservation> reservations = Instancio.ofList(Reservation.class).size(3)
                 .set(field(Reservation::getStatus), ReservationStatus.SUCCESS)
                 .create();
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdsWithLock(concertScheduleId, seatIds))
                 .thenReturn(reservations);
 
         // when
-        boolean result = sut.isReservedSeat(concertScheduleId, seatId, now);
+        boolean result = sut.isReservedSeats(concertScheduleId, seatIds, now);
 
         // then
         assertThat(result).isTrue();
@@ -96,18 +96,18 @@ class ReservationServiceTest {
     void isReservedSeatTrueWhenAllReservationIsSuspend() {
         // given
         long concertScheduleId = 1L;
-        long seatId = 1L;
+        List<Long> seatIds = List.of(1L, 2L, 3L);
         LocalDateTime now = LocalDateTime.of(2025, 1, 6, 23, 0, 0);
         List<Reservation> reservations = Instancio.ofList(Reservation.class).size(3)
                 .set(field(Reservation::getStatus), ReservationStatus.SUSPEND)
                 .set(field(Reservation::getExpiredAt), now.plusMinutes(3)) // 아직 만료되지 않음
                 .create();
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdsWithLock(concertScheduleId, seatIds))
                 .thenReturn(reservations);
 
         // when
-        boolean result = sut.isReservedSeat(concertScheduleId, seatId, now);
+        boolean result = sut.isReservedSeats(concertScheduleId, seatIds, now);
 
         // then
         assertThat(result).isTrue();
@@ -118,18 +118,18 @@ class ReservationServiceTest {
     void isReservedSeatFalseWhenAllReservationIsSuspendButExpired() {
         // given
         long concertScheduleId = 1L;
-        long seatId = 1L;
+        List<Long> seatIds = List.of(1L, 2L, 3L);
         LocalDateTime now = LocalDateTime.of(2025, 1, 6, 23, 0, 0);
         List<Reservation> reservations = Instancio.ofList(Reservation.class).size(3)
                 .set(field(Reservation::getStatus), ReservationStatus.SUSPEND)
                 .set(field(Reservation::getExpiredAt), now.minusMinutes(3)) // 만료됨
                 .create();
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdsWithLock(concertScheduleId, seatIds))
                 .thenReturn(reservations);
 
         // when
-        boolean result = sut.isReservedSeat(concertScheduleId, seatId, now);
+        boolean result = sut.isReservedSeats(concertScheduleId, seatIds, now);
 
         // then
         assertThat(result).isFalse();
@@ -140,7 +140,7 @@ class ReservationServiceTest {
     void isReservedSeatTrueWhenReservationIsMixed() {
         // given
         long concertScheduleId = 1L;
-        long seatId = 1L;
+        List<Long> seatIds = List.of(1L, 2L, 3L);
         LocalDateTime now = LocalDateTime.of(2025, 1, 6, 23, 0, 0);
         List<Reservation> successReservations = Instancio.ofList(Reservation.class).size(3)
                 .set(field(Reservation::getStatus), ReservationStatus.SUCCESS)
@@ -152,11 +152,11 @@ class ReservationServiceTest {
         mixedReservations.addAll(successReservations);
         mixedReservations.addAll(cancelReservations);
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdsWithLock(concertScheduleId, seatIds))
                 .thenReturn(mixedReservations);
 
         // when
-        boolean result = sut.isReservedSeat(concertScheduleId, seatId, now);
+        boolean result = sut.isReservedSeats(concertScheduleId, seatIds, now);
 
         // then
         assertThat(result).isTrue();

--- a/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceTest.java
+++ b/src/test/java/com/sion/concertbooking/domain/service/ReservationServiceTest.java
@@ -39,7 +39,7 @@ class ReservationServiceTest {
         long seatId = 1L;
         LocalDateTime now = LocalDateTime.of(2025, 1, 6, 23, 0, 0);
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatId(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
                 .thenReturn(List.of());
 
         // when
@@ -60,7 +60,7 @@ class ReservationServiceTest {
                 .set(field(Reservation::getStatus), ReservationStatus.CANCEL)
                 .create();
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatId(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
                 .thenReturn(reservations);
 
         // when
@@ -81,7 +81,7 @@ class ReservationServiceTest {
                 .set(field(Reservation::getStatus), ReservationStatus.SUCCESS)
                 .create();
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatId(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
                 .thenReturn(reservations);
 
         // when
@@ -103,7 +103,7 @@ class ReservationServiceTest {
                 .set(field(Reservation::getExpiredAt), now.plusMinutes(3)) // 아직 만료되지 않음
                 .create();
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatId(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
                 .thenReturn(reservations);
 
         // when
@@ -125,7 +125,7 @@ class ReservationServiceTest {
                 .set(field(Reservation::getExpiredAt), now.minusMinutes(3)) // 만료됨
                 .create();
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatId(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
                 .thenReturn(reservations);
 
         // when
@@ -152,7 +152,7 @@ class ReservationServiceTest {
         mixedReservations.addAll(successReservations);
         mixedReservations.addAll(cancelReservations);
 
-        when(reservationRepository.findByConcertScheduleIdAndSeatId(concertScheduleId, seatId))
+        when(reservationRepository.findByConcertScheduleIdAndSeatIdWithLock(concertScheduleId, seatId))
                 .thenReturn(mixedReservations);
 
         // when

--- a/src/test/java/com/sion/concertbooking/integrationtest/concurrency/PointServiceConcurrencyTest.java
+++ b/src/test/java/com/sion/concertbooking/integrationtest/concurrency/PointServiceConcurrencyTest.java
@@ -1,0 +1,202 @@
+package com.sion.concertbooking.integrationtest.concurrency;
+
+import com.sion.concertbooking.domain.info.PointInfo;
+import com.sion.concertbooking.domain.service.PointService;
+import com.sion.concertbooking.test.TestDataCleaner;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class PointServiceConcurrencyTest {
+
+    @Autowired
+    PointService pointService;
+
+    @Autowired
+    TestDataCleaner testDataCleaner;
+
+    @BeforeEach
+    void setUp() {
+        testDataCleaner.cleanUp();
+    }
+
+    @DisplayName("현재 포인트가 0원일 때, 100원씩 포인트를 20번 충전하면 총 2000원이 충전되어야 한다.")
+    @Test
+    void chargePointConcurrently() throws Exception {
+        // given
+        long userId = 1L;
+        int amount = 100;
+        pointService.createPoint(userId); // 포인트 지갑 생성
+
+        final int numOfExecute = 20;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(numOfExecute);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < numOfExecute; i++) {
+            executorService.submit(() -> {
+                try {
+                    pointService.chargePoint(userId, amount);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(numOfExecute);
+        assertThat(failCount.get()).isZero();
+
+        PointInfo pointInfo = pointService.getPointByUserId(userId);
+        assertThat(pointInfo.amount()).isEqualTo(2000);
+    }
+
+    @DisplayName("현재 포인트가 10,000원일 때 100원씩 포인트를 20번 사용하면, 도합 8000원이 남아야 한다.")
+    @Test
+    void usePointConcurrently() throws Exception {
+        // given
+        long userId = 1L;
+        int amount = 100;
+        pointService.createPoint(userId); // 포인트 지갑 생성
+        pointService.chargePoint(userId, 10_000); // 테스트를 위해 포인트 충전을 미리 해놓는다.
+
+        final int numOfExecute = 20;
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(numOfExecute);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        for (int i = 0; i < numOfExecute; i++) {
+            executorService.submit(() -> {
+                try {
+                    pointService.usePoint(userId, amount);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(numOfExecute);
+        assertThat(failCount.get()).isZero();
+
+        PointInfo pointInfo = pointService.getPointByUserId(userId);
+        assertThat(pointInfo.amount()).isEqualTo(8000);
+    }
+
+    @DisplayName("현재 포인트가 1000원이고 (+1000원 충전) -> (-2000원 사용) 요청이 차례로 들어오면, 0원이 되어야 한다.")
+    @Test
+    void chargeAndUsePointConcurrently() throws Exception {
+        // given
+        long userId = 1L;
+        pointService.createPoint(userId); // 포인트 지갑 생성
+        pointService.chargePoint(userId, 1000); // 초기 포인트 1000원
+
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        executorService.submit(() -> {
+            try {
+                pointService.chargePoint(userId, 1000);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        executorService.submit(() -> {
+            try {
+                pointService.usePoint(userId, 2000);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                latch.countDown();
+            }
+        });
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(2);
+        assertThat(failCount.get()).isZero();
+
+        PointInfo pointInfo = pointService.getPointByUserId(userId);
+        assertThat(pointInfo.amount()).isZero();
+    }
+
+    @DisplayName("현재 포인트가 1000원이고 (-2000원 사용) -> (+1000원 충전) 요청이 차례로 들어오면, 2000원이 되어야 한다.")
+    @Test
+    void useAndChargePointConcurrently() throws Exception {
+        // given
+        long userId = 1L;
+        pointService.createPoint(userId); // 포인트 지갑 생성
+        pointService.chargePoint(userId, 1000); // 초기 포인트 1000원
+
+        ExecutorService executorService = Executors.newFixedThreadPool(10);
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        // when
+        executorService.submit(() -> {
+            try {
+                pointService.usePoint(userId, 2000);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                latch.countDown();
+            }
+        });
+
+        executorService.submit(() -> {
+            try {
+                pointService.chargePoint(userId, 1000);
+                successCount.incrementAndGet();
+            } catch (Exception e) {
+                failCount.incrementAndGet();
+            } finally {
+                latch.countDown();
+            }
+        });
+        latch.await();
+        executorService.shutdown();
+
+        // then
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(1); // 첫번째 요청은 잔액부족으로 실패
+
+        PointInfo pointInfo = pointService.getPointByUserId(userId);
+        assertThat(pointInfo.amount()).isEqualTo(2000);
+    }
+
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=concertbooking-test
 
 spring.jpa.hibernate.ddl-auto=create
-spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.show-sql=true


### PR DESCRIPTION
### **커밋 링크**
- [fix: 포인트 충전/사용 동시성 이슈 해결](https://github.com/nohsion/concert-booking/commit/b2575661609b9945c2ab45d1e20c71ffaa8f77c5)
- [test: 데드락 발생하던 테스트 에러 해결](https://github.com/nohsion/concert-booking/commit/4141760c112bdda1eef6dda0645bc1ca87ad0bde)

---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1: 비관적락 데드락 발생
  - **동시성 이슈 해결 방안**: 예약 테이블 조회시 비관적 락 `select for update` 후, (`scheduleId, seatId`)에 해당하는 예약 row가 없으면 `insert`하는 로직 (물리적 FK 걸지 않음)
  - **테스트**: 유저 3명이 동시에 같은 (공연일정, 좌석)에 대해 예약 시도를 하면 1개만 성공하도록 구현했습니다. 그런데, 데드락이 발생을 했습니다. 
  - 그런데 미리 예약 row를 하나 넣어준 후에 테스트를 하면 데드락이 발생을 하지 않더라구요.. (초기데이터를 넣어줘서 test는 통과를 시켰습니다)
  - 초기 데이터 수가 0개이면 데드락이 발생하는 것 같습니다만, 정확한 원인을 아직 파악하지 못해서 질문 드립니다..!!
  - 커밋 내역: [test: 데드락 발생하던 테스트 에러 해결](https://github.com/nohsion/concert-booking/commit/4141760c112bdda1eef6dda0645bc1ca87ad0bde)

에러 화면

- 데드락 발생
  - <img width="685" alt="image" src="https://github.com/user-attachments/assets/14de2443-91ac-49ca-8301-7a017a4e699c" />
- 의도한 예외 발생
  - <img width="628" alt="image" src="https://github.com/user-attachments/assets/d645eb1f-9a5c-4562-a6f9-3d80bbe3291e" />


---
### **이번주 KPT 회고**

### Keep
<!-- 유지해야 할 좋은 점 -->

### Problem
<!--개선이 필요한 점-->

### Try
<!-- 새롭게 시도할 점 -->