### PR TITLE
공연 예매 기능에 Redis 분산락 적용하기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,6 @@ out/
 
 ### Docker DB ###
 db/
+redis-db/
 
 logs/

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.43.0'
 
 	compileOnly 'org.projectlombok:lombok'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,14 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
 
+  redis:
+    image: redis:7.4.2
+    container_name: hh-redis
+    ports:
+      - "56379:6379"
+    volumes:
+      - ./redis-db:/data
+
 networks:
   default:
     driver: bridge

--- a/src/main/java/com/sion/concertbooking/application/reservation/ConcertReservationFacade.java
+++ b/src/main/java/com/sion/concertbooking/application/reservation/ConcertReservationFacade.java
@@ -10,7 +10,6 @@ import com.sion.concertbooking.domain.concert.ConcertService;
 import com.sion.concertbooking.domain.reservation.ReservationService;
 import com.sion.concertbooking.domain.seat.SeatService;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,7 +34,6 @@ public class ConcertReservationFacade {
         this.seatService = seatService;
     }
 
-    @Transactional
     public List<ReservationResult> reserve(ReservationCriteria criteria) {
         LocalDateTime now = LocalDateTime.now();
 

--- a/src/main/java/com/sion/concertbooking/domain/reservation/ReservationRepository.java
+++ b/src/main/java/com/sion/concertbooking/domain/reservation/ReservationRepository.java
@@ -8,6 +8,8 @@ public interface ReservationRepository {
 
     List<Reservation> saveAll(List<Reservation> reservations);
 
+    List<Reservation> findByConcertScheduleIdAndSeatIds(long concertScheduleId, List<Long> seatIds);
+
     List<Reservation> findByConcertScheduleIdAndSeatIdsWithLock(long concertScheduleId, List<Long> seatIds);
 
     Optional<Reservation> findById(long reservationId);

--- a/src/main/java/com/sion/concertbooking/infrastructure/config/RedissonConfiguration.java
+++ b/src/main/java/com/sion/concertbooking/infrastructure/config/RedissonConfiguration.java
@@ -1,0 +1,27 @@
+package com.sion.concertbooking.infrastructure.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfiguration {
+
+    private static final String PROTOCOL = "redis://";
+
+    @Value("${redisson.host}")
+    private String host;
+    @Value("${redisson.port}")
+    private int port;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+        config.useSingleServer()
+                .setAddress(PROTOCOL + host + ":" + port);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/com/sion/concertbooking/infrastructure/impl/ReservationRepositoryIml.java
+++ b/src/main/java/com/sion/concertbooking/infrastructure/impl/ReservationRepositoryIml.java
@@ -31,6 +31,11 @@ public class ReservationRepositoryIml implements ReservationRepository {
     }
 
     @Override
+    public List<Reservation> findByConcertScheduleIdAndSeatIds(final long concertScheduleId, final List<Long> seatIds) {
+        return reservationJpaRepository.findByConcertScheduleIdAndSeatIdIn(concertScheduleId, seatIds);
+    }
+
+    @Override
     public List<Reservation> findByConcertScheduleIdAndSeatIdsWithLock(final long concertScheduleId, final List<Long> seatIds) {
         return reservationJpaRepository.findByConcertScheduleIdAndSeatIdsWithLock(concertScheduleId, seatIds);
     }

--- a/src/main/java/com/sion/concertbooking/infrastructure/jpa/ReservationJpaRepository.java
+++ b/src/main/java/com/sion/concertbooking/infrastructure/jpa/ReservationJpaRepository.java
@@ -13,6 +13,8 @@ import java.util.List;
 @Repository
 public interface ReservationJpaRepository extends JpaRepository<Reservation, Long> {
 
+    List<Reservation> findByConcertScheduleIdAndSeatIdIn(long concertScheduleId, List<Long> seatIds);
+
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT r FROM Reservation r WHERE r.concertScheduleId = :concertScheduleId AND r.seatId IN :seatIds")
     List<Reservation> findByConcertScheduleIdAndSeatIdsWithLock(

--- a/src/main/java/com/sion/concertbooking/intefaces/aspect/AopForTransaction.java
+++ b/src/main/java/com/sion/concertbooking/intefaces/aspect/AopForTransaction.java
@@ -1,0 +1,18 @@
+package com.sion.concertbooking.intefaces.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * AOP에서 트랜잭션을 호출하기 위한 클래스
+ */
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(final ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/com/sion/concertbooking/intefaces/aspect/CustomSpringELParser.java
+++ b/src/main/java/com/sion/concertbooking/intefaces/aspect/CustomSpringELParser.java
@@ -1,0 +1,48 @@
+package com.sion.concertbooking.intefaces.aspect;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.util.*;
+import java.util.stream.Stream;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CustomSpringELParser {
+
+    private static final SpelExpressionParser PARSER = new SpelExpressionParser();
+
+    public static Object getDynamicValue(String[] parameters, Object[] args, String key) {
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameters.length; i++) {
+            context.setVariable(parameters[i], args[i]);
+        }
+
+        return PARSER.parseExpression(key).getValue(context, Object.class);
+    }
+
+    public static Object[] getDynamicValues(String[] parameters, Object[] args, String[] keys) {
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameters.length; i++) {
+            context.setVariable(parameters[i], args[i]);
+        }
+
+        return Arrays.stream(keys)
+                .map(PARSER::parseExpression)
+                .map(expression -> expression.getValue(context, Object.class))
+                .filter(Objects::nonNull)
+                .flatMap(value -> {
+                    if (value instanceof Collection<?> collection) {
+                        return collection.stream();
+                    }
+                    if (value instanceof Object[] array) {
+                        return Arrays.stream(array);
+                    }
+                    return Stream.of(value);
+                })
+                .toArray();
+    }
+}

--- a/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedLock.java
+++ b/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedLock.java
@@ -1,0 +1,28 @@
+package com.sion.concertbooking.intefaces.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String key();
+
+    String keyPrefix() default "";
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락 획득을 위해 기다리는 시간
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 획득 이후, leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedLockAspect.java
+++ b/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedLockAspect.java
@@ -1,0 +1,89 @@
+package com.sion.concertbooking.intefaces.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Aspect
+@Component
+public class DistributedLockAspect {
+
+    private static final String LOCK_PREFIX = "lock:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    public DistributedLockAspect(RedissonClient redissonClient, AopForTransaction aopForTransaction) {
+        this.redissonClient = redissonClient;
+        this.aopForTransaction = aopForTransaction;
+    }
+
+    @Around("@annotation(DistributedLock)")
+    public Object lock(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String lockKey = LOCK_PREFIX + CustomSpringELParser.getDynamicValue(
+                signature.getParameterNames(),
+                joinPoint.getArgs(),
+                distributedLock.key()
+        );
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            boolean acquired = lock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!acquired) {
+                return false;
+            }
+            return aopForTransaction.proceed(joinPoint);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Around("@annotation(DistributedMultiLock)")
+    public Object multiLock(ProceedingJoinPoint joinPoint) throws Throwable {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+
+        DistributedMultiLock distributedMultiLock = method.getAnnotation(DistributedMultiLock.class);
+
+        Object[] dynamicValues = CustomSpringELParser.getDynamicValues(
+                signature.getParameterNames(),
+                joinPoint.getArgs(),
+                distributedMultiLock.keys()
+        );
+        List<String> lockKeyNames = Arrays.stream(dynamicValues)
+                .map(String::valueOf)
+                .map(key -> LOCK_PREFIX + distributedMultiLock.keyPrefix() + key)
+                .toList();
+
+        RLock multiLock = redissonClient.getMultiLock(
+                lockKeyNames.stream()
+                        .map(redissonClient::getLock)
+                        .toArray(RLock[]::new)
+        );
+
+        try {
+            boolean acquired = multiLock.tryLock(distributedMultiLock.waitTime(), distributedMultiLock.leaseTime(), distributedMultiLock.timeUnit());
+            if (!acquired) {
+                return false;
+            }
+            return aopForTransaction.proceed(joinPoint);
+        } finally {
+            multiLock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedLockAspect.java
+++ b/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedLockAspect.java
@@ -35,7 +35,7 @@ public class DistributedLockAspect {
 
         DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
 
-        String lockKey = LOCK_PREFIX + CustomSpringELParser.getDynamicValue(
+        String lockKey = LOCK_PREFIX + distributedLock.keyPrefix() + CustomSpringELParser.getDynamicValue(
                 signature.getParameterNames(),
                 joinPoint.getArgs(),
                 distributedLock.key()

--- a/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedMultiLock.java
+++ b/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedMultiLock.java
@@ -1,0 +1,31 @@
+package com.sion.concertbooking.intefaces.aspect;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedMultiLock {
+
+    String[] keys();
+
+    /**
+     * 락 Key 에 prefix 를 추가한다
+     */
+    String keyPrefix() default "";
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    /**
+     * 락 획득을 위해 기다리는 시간
+     */
+    long waitTime() default 5L;
+
+    /**
+     * 락 획득 이후, leaseTime 이 지나면 락을 해제한다
+     */
+    long leaseTime() default 3L;
+}

--- a/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedMultiLock.java
+++ b/src/main/java/com/sion/concertbooking/intefaces/aspect/DistributedMultiLock.java
@@ -22,7 +22,7 @@ public @interface DistributedMultiLock {
     /**
      * 락 획득을 위해 기다리는 시간
      */
-    long waitTime() default 5L;
+    long waitTime() default 1L;
 
     /**
      * 락 획득 이후, leaseTime 이 지나면 락을 해제한다

--- a/src/main/java/com/sion/concertbooking/intefaces/presentation/accesslog/AccessLogAspect.java
+++ b/src/main/java/com/sion/concertbooking/intefaces/presentation/accesslog/AccessLogAspect.java
@@ -6,12 +6,14 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.time.ZonedDateTime;
 
+@Order(0)
 @Slf4j
 @Component
 @Aspect

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,4 +9,9 @@ spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.format_sql=false
 spring.jpa.show-sql=false
 
+# Async Logging
 post-process.threads=10
+
+# Redisson
+redisson.host=localhost
+redisson.port=56379

--- a/src/test/java/com/sion/concertbooking/test/MariaDBTestcontainersConfiguration.java
+++ b/src/test/java/com/sion/concertbooking/test/MariaDBTestcontainersConfiguration.java
@@ -6,7 +6,7 @@ import org.testcontainers.containers.MariaDBContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
-class TestcontainersConfiguration {
+class MariaDBTestcontainersConfiguration {
 
 	public static final MariaDBContainer<?> MARIADB_CONTAINER;
 

--- a/src/test/java/com/sion/concertbooking/test/RedissonTestcontainersConfiguration.java
+++ b/src/test/java/com/sion/concertbooking/test/RedissonTestcontainersConfiguration.java
@@ -1,0 +1,29 @@
+package com.sion.concertbooking.test;
+
+import jakarta.annotation.PreDestroy;
+import org.springframework.context.annotation.Configuration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@Configuration
+class RedissonTestcontainersConfiguration {
+
+    public static final GenericContainer<?> REDIS_CONTAINER;
+
+    static {
+        REDIS_CONTAINER = new GenericContainer<>(DockerImageName.parse("redis:7.4.2"))
+                .withExposedPorts(6379)
+                .withReuse(true);
+        REDIS_CONTAINER.start();
+
+        System.setProperty("redisson.host", REDIS_CONTAINER.getHost());
+        System.setProperty("redisson.port", String.valueOf(REDIS_CONTAINER.getMappedPort(6379)));
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        if (REDIS_CONTAINER.isRunning()) {
+            REDIS_CONTAINER.stop();
+        }
+    }
+}


### PR DESCRIPTION
### **커밋 링크**
- [콘서트 예약에 Redisson 멀티락 분산락 적용](https://github.com/nohsion/concert-booking/commit/8f17bab5cb181a68f76cc08888a82719e3f9f6d8)
- [refactor: MultiLock 대신 for문으로 구현해보기](https://github.com/nohsion/concert-booking/commit/3ad2f3657237fb8eeaa66620b0046f97d0d19623)
---
### **리뷰 포인트(질문)**
- 리뷰 포인트 1: Facade에 분산락 AOP를 달아줘야 할지, Service에 달아줘야 할지 헷갈립니다.
  - 지금은 예약서비스에서만 write하고 나머지 Facade에서는 조회만 해서 Service에만 달아줘도 문제가 없는 것 같은데요 (특이한 케이스인 것 같음) 롤백을 하려면 Facade 전체에 걸어주는게 맞지 않나 싶습니다.
  - 한편으론 예약서비스 자체에서 동시성 제어를 해주는게 맞을 것 같은데, Facade에서 하는게 좀 어색한것 같습니다.
- 리뷰 포인트 2: 분산락 AOP에서 REQUIRES_NEW를 통해 트랜잭션을 새롭게 열어주면 해당 트랜잭션에 대해서만 락을 걸수 있을 것 같은데, 이때 부모 트랜잭션까지 있다면 어떻게 되나요? `Tx1 시작 -> Lock 획득 -> Tx2 시작 -> Tx2 종료 -> Lock 해제 -> Tx1 종료` 이렇게 되는걸까요.?!
---
